### PR TITLE
Personalize Dopefolio template for David Adewale

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,8 +4,8 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta http-equiv="X-UA-Compatible" content="ie=edge" />
-    <title>Dopefolio</title>
-    <meta name="description" content="Portfolio Template for Developer" />
+    <title>David Adewale</title>
+    <meta name="description" content="Portfolio of Data Analyst David Adewale" />
 
     <link rel="stylesheet" href="css/style.css" />
 
@@ -23,11 +23,11 @@
           <div class="header__logo-img-cont">
             <img
               src="./assets/png/john-doe.png"
-              alt="Ram Maheshwari Logo Image"
+              alt="David Adewale Logo Image"
               class="header__logo-img"
             />
           </div>
-          <span class="header__logo-sub">John Doe</span>
+          <span class="header__logo-sub">David Adewale</span>
         </div>
         <div class="header__main">
           <ul class="header__links">
@@ -84,12 +84,13 @@
     </header>
     <section class="home-hero">
       <div class="home-hero__content">
-        <h1 class="heading-primary">Hey, My name is John Doe</h1>
+        <h1 class="heading-primary">Hi, I’m David</h1>
         <div class="home-hero__info">
           <p class="text-primary">
-            Lorem ipsum dolor sit amet consectetur adipisicing elit. Hic facilis
-            tempora explicabo quae quod deserunt eius sapiente solutions for
-            complex problems
+            SQL, Python, Power BI, Tableau, and Excel are my tools to unlock
+            the hidden stories within your data. I transform complex data into
+            insights that turn confusion into clarity. Ready to explore more?
+            Let’s go!
           </p>
         </div>
         <div class="home-hero__cta">
@@ -98,49 +99,29 @@
       </div>
       <div class="home-hero__socials">
         <div class="home-hero__social">
-          <a href="#" class="home-hero__social-icon-link">
+          <a
+            href="https://linkedin.com/in/davale/"
+            class="home-hero__social-icon-link"
+            target="_blank"
+            rel="noreferrer"
+          >
             <img
               src="./assets/png/linkedin-ico.png"
-              alt="icon"
-              class="home-hero__social-icon"
-            />
-          </a>
-        </div>
-        <div class="home-hero__social">
-          <a href="#" class="home-hero__social-icon-link">
-            <img
-              src="./assets/png/github-ico.png"
-              alt="icon"
-              class="home-hero__social-icon"
-            />
-          </a>
-        </div>
-        <div class="home-hero__social">
-          <a href="#" class="home-hero__social-icon-link">
-            <img
-              src="./assets/png/twitter-ico.png"
-              alt="icon"
-              class="home-hero__social-icon"
-            />
-          </a>
-        </div>
-        <div class="home-hero__social">
-          <a href="#" class="home-hero__social-icon-link">
-            <img
-              src="./assets/png/yt-ico.png"
-              alt="icon"
+              alt="LinkedIn"
               class="home-hero__social-icon"
             />
           </a>
         </div>
         <div class="home-hero__social">
           <a
-            href="#"
-            class="home-hero__social-icon-link home-hero__social-icon-link--bd-none"
+            href="https://github.com/davalework"
+            class="home-hero__social-icon-link"
+            target="_blank"
+            rel="noreferrer"
           >
             <img
-              src="./assets/png/insta-ico.png"
-              alt="icon"
+              src="./assets/png/github-ico.png"
+              alt="GitHub"
               class="home-hero__social-icon"
             />
           </a>
@@ -155,8 +136,8 @@
         <h2 class="heading heading-sec heading-sec__mb-med">
           <span class="heading-sec__main">About Me</span>
           <span class="heading-sec__sub">
-            Lorem ipsum dolor sit amet consectetur adipisicing elit. Hic facilis
-            tempora explicabo quae quod deserunt eius sapiente
+            I turn messy data into clear, actionable stories—blending business
+            analysis, analytics, and design to drive smarter decisions.
           </span>
         </h2>
         <div class="about__content">
@@ -164,21 +145,31 @@
             <h3 class="about__content-title">Get to know me!</h3>
             <div class="about__content-details">
               <p class="about__content-details-para">
-                Hey! It's
-                <strong>John Doe</strong>
-                and I'm a <strong> Frontend Web Developer </strong> located in
-                Los Angeles. I've done
-                <strong> remote </strong>
-                projects for agencies, consulted for startups, and collaborated
-                with talented people to create
-                <strong>digital products </strong>
-                for both business and consumer use.
+                Hey! I’m <strong>David Adewale</strong>, a data analyst with an
+                entrepreneurial streak. I studied Business Computing
+                (Entrepreneurship) at Goldsmiths, University of London and hold
+                BCS Business Analysis Foundation, BCS Data Foundations, and
+                CompTIA Data+ certifications.
               </p>
               <p class="about__content-details-para">
-                I'm a bit of a digital product junky. Over the years, I've used
-                hundreds of web and mobile apps in different industries and
-                verticals. Feel free to
-                <strong>contact</strong> me here.
+                Isn’t the world fascinating? Every application, every business
+                challenge, every line of code seems to hide a secret story. That
+                curiosity led me from an early love of technology to uncovering
+                how data drives decisions and shapes strategy.
+              </p>
+              <p class="about__content-details-para">
+                When I’m not solving business problems, you’ll probably find me
+                exploring creative outlets like digital art, music, or
+                photography. This artistic streak helps me think visually and
+                communicate the stories within data.
+              </p>
+              <p class="about__content-details-para">
+                Equipped with skills in Excel, SQL, Python, and data
+                visualisation tools, I uncover trends that optimise processes
+                and reveal new opportunities. If you’re looking for someone who
+                can bridge the gap between business strategy, data analysis, and
+                creative communication, let’s connect—there’s always a new story
+                waiting to be told.
               </p>
             </div>
             <a href="./#contact" class="btn btn--med btn--theme dynamicBgClr"
@@ -188,18 +179,11 @@
           <div class="about__content-skills">
             <h3 class="about__content-title">My Skills</h3>
             <div class="skills">
-              <div class="skills__skill">HTML</div>
-              <div class="skills__skill">CSS</div>
-              <div class="skills__skill">JavaScript</div>
-              <div class="skills__skill">React</div>
-              <div class="skills__skill">SASS</div>
-              <div class="skills__skill">GIT</div>
-              <div class="skills__skill">Shopify</div>
-              <div class="skills__skill">Wordpress</div>
-              <div class="skills__skill">Google ADS</div>
-              <div class="skills__skill">Facebook Ads</div>
-              <div class="skills__skill">Android</div>
-              <div class="skills__skill">IOS</div>
+              <div class="skills__skill">Excel</div>
+              <div class="skills__skill">SQL</div>
+              <div class="skills__skill">Python</div>
+              <div class="skills__skill">Tableau</div>
+              <div class="skills__skill">Power BI</div>
             </div>
           </div>
         </div>
@@ -210,8 +194,8 @@
         <h2 class="heading heading-sec heading-sec__mb-bg">
           <span class="heading-sec__main">Projects</span>
           <span class="heading-sec__sub">
-            Lorem ipsum dolor sit amet consectetur adipisicing elit. Hic facilis
-            tempora explicabo quae quod deserunt eius sapiente
+            Projects highlighting data prep, quality, analysis, and clear
+            storytelling.
           </span>
         </h2>
 
@@ -226,62 +210,15 @@
               />
             </div>
             <div class="projects__row-content">
-              <h3 class="projects__row-content-title">Project 1</h3>
+              <h3 class="projects__row-content-title">
+                Spotify vs. Apple Music
+              </h3>
               <p class="projects__row-content-desc">
-                Lorem ipsum dolor sit amet consectetur adipisicing elit. Hic
-                facilis tempora, explicabo quae quod deserunt eius sapiente
-                praesentium.
+                Comparing the titans of music streaming by revenue, users,
+                premium conversion, and geography.
               </p>
               <a
                 href="./project-1.html"
-                class="btn btn--med btn--theme dynamicBgClr"
-                target="_blank"
-                >Case Study</a
-              >
-            </div>
-          </div>
-          <div class="projects__row">
-            <div class="projects__row-img-cont">
-              <img
-                src="./assets/jpeg/project-mockup-example.jpeg"
-                alt="Software Screenshot"
-                class="projects__row-img"
-                loading="lazy"
-              />
-            </div>
-            <div class="projects__row-content">
-              <h3 class="projects__row-content-title">Project 2</h3>
-              <p class="projects__row-content-desc">
-                Lorem ipsum dolor sit amet consectetur adipisicing elit. Hic
-                facilis tempora, explicabo quae quod deserunt eius sapiente
-                praesentium.
-              </p>
-              <a
-                href="./project-2.html"
-                class="btn btn--med btn--theme dynamicBgClr"
-                target="_blank"
-                >Case Study</a
-              >
-            </div>
-          </div>
-          <div class="projects__row">
-            <div class="projects__row-img-cont">
-              <img
-                src="./assets/jpeg/project-mockup-example.jpeg"
-                alt="Software Screenshot"
-                class="projects__row-img"
-                loading="lazy"
-              />
-            </div>
-            <div class="projects__row-content">
-              <h3 class="projects__row-content-title">Project 3</h3>
-              <p class="projects__row-content-desc">
-                Lorem ipsum dolor sit amet consectetur adipisicing elit. Hic
-                facilis tempora, explicabo quae quod deserunt eius sapiente
-                praesentium.
-              </p>
-              <a
-                href="./project-3.html"
                 class="btn btn--med btn--theme dynamicBgClr"
                 target="_blank"
                 >Case Study</a
@@ -294,12 +231,28 @@
     <section id="contact" class="contact sec-pad dynamicBg">
       <div class="main-container">
         <h2 class="heading heading-sec heading-sec__mb-med">
-          <span class="heading-sec__main heading-sec__main--lt">Contact</span>
+          <span class="heading-sec__main heading-sec__main--lt">LET'S CONNECT!</span>
           <span class="heading-sec__sub heading-sec__sub--lt">
-            Lorem ipsum dolor sit amet consectetur adipisicing elit. Hic facilis
-            tempora explicabo quae quod deserunt eius sapiente
+            Your data, my expertise. Together, we’ll unlock insights that drive
+            success.
           </span>
         </h2>
+        <div class="contact__info">
+          <p>London, UK</p>
+          <p>
+            <a href="https://linkedin.com/in/davale/" target="_blank" rel="noreferrer"
+              >linkedin.com/in/davale/</a
+            >
+          </p>
+          <p>
+            <a href="https://github.com/davalework" target="_blank" rel="noreferrer"
+              >github.com/davalework</a
+            >
+          </p>
+          <p>
+            <a href="mailto:davalework@outlook.com">davalework@outlook.com</a>
+          </p>
+        </div>
         <div class="contact__form-container">
           <form action="#" class="contact__form">
             <div class="contact__form-field">
@@ -351,48 +304,35 @@
               <span>Social</span>
             </h2>
             <div class="main-footer__social-cont">
-              <a target="_blank" rel="noreferrer" href="#">
+              <a
+                target="_blank"
+                rel="noreferrer"
+                href="https://linkedin.com/in/davale/"
+              >
                 <img
                   class="main-footer__icon"
                   src="./assets/png/linkedin-ico.png"
-                  alt="icon"
+                  alt="LinkedIn"
                 />
               </a>
-              <a target="_blank" rel="noreferrer" href="#">
-                <img
-                  class="main-footer__icon"
-                  src="./assets/png/github-ico.png"
-                  alt="icon"
-                />
-              </a>
-              <a target="_blank" rel="noreferrer" href="#">
-                <img
-                  class="main-footer__icon"
-                  src="./assets/png/twitter-ico.png"
-                  alt="icon"
-                />
-              </a>
-              <a target="_blank" rel="noreferrer" href="#">
-                <img
-                  class="main-footer__icon"
-                  src="./assets/png/yt-ico.png"
-                  alt="icon"
-                />
-              </a>
-              <a target="_blank" rel="noreferrer" href="#">
+              <a
+                target="_blank"
+                rel="noreferrer"
+                href="https://github.com/davalework"
+              >
                 <img
                   class="main-footer__icon main-footer__icon--mr-none"
-                  src="./assets/png/insta-ico.png"
-                  alt="icon"
+                  src="./assets/png/github-ico.png"
+                  alt="GitHub"
                 />
               </a>
             </div>
           </div>
           <div class="main-footer__row main-footer__row-2">
-            <h4 class="heading heading-sm text-lt">John Doe</h4>
+            <h4 class="heading heading-sm text-lt">David Adewale</h4>
             <p class="main-footer__short-desc">
-              Lorem ipsum dolor sit amet consectetur adipisicing elit facilis
-              tempora explicabo quae quod deserunt
+              Your data, my expertise. Together, we’ll unlock insights that
+              drive success.
             </p>
           </div>
         </div>

--- a/project-1.html
+++ b/project-1.html
@@ -4,8 +4,8 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta http-equiv="X-UA-Compatible" content="ie=edge" />
-    <title>Case Study of Project 1</title>
-    <meta name="description" content="Case study page of Project" />
+    <title>Spotify vs. Apple Music</title>
+    <meta name="description" content="Case study comparing Spotify and Apple Music" />
 
     <link rel="stylesheet" href="css/style.css" />
 
@@ -23,11 +23,11 @@
           <div class="header__logo-img-cont">
             <img
               src="./assets/png/john-doe.png"
-              alt="Ram Maheshwari Logo Image"
+              alt="David Adewale Logo Image"
               class="header__logo-img"
             />
           </div>
-          <span class="header__logo-sub">John Doe</span>
+          <span class="header__logo-sub">David Adewale</span>
         </div>
         <div class="header__main">
           <ul class="header__links">
@@ -84,16 +84,12 @@
     </header>
     <section class="project-cs-hero">
       <div class="project-cs-hero__content">
-        <h1 class="heading-primary">Project 1</h1>
+        <h1 class="heading-primary">Spotify vs. Apple Music</h1>
         <div class="project-cs-hero__info">
           <p class="text-primary">
-            Lorem ipsum dolor sit amet consectetur adipisicing elit. Dignissimos
-            in numquam incidunt earum quaerat cum fuga, atque similique natus
-            nobis sit.
+            Comparing the titans of music streaming by revenue, users, premium
+            conversion, and geography.
           </p>
-        </div>
-        <div class="project-cs-hero__cta">
-          <a href="#" class="btn btn--bg" target="_blank">Live Link</a>
         </div>
       </div>
     </section>
@@ -111,53 +107,25 @@
             <div class="project-details__desc">
               <h3 class="project-details__content-title">Project Overview</h3>
               <p class="project-details__desc-para">
-                Lorem ipsum dolor sit amet consectetur adipisicing elit. Neque
-                alias tenetur minus quaerat aliquid, aut provident blanditiis,
-                deleniti aspernatur ipsam eaque veniam voluptatem corporis vitae
-                mollitia laborum corrupti ullam rem. Lorem ipsum dolor sit amet
-                consectetur adipisicing elit. Neque alias tenetur minus quaerat
-                aliquid, aut provident blanditiis, deleniti aspernatur ipsam
-                eaque veniam voluptatem corporis vitae mollitia laborum corrupti
-                ullam rem?
+                A deep dive into revenue, user growth, premium conversion, and
+                geographic reach to reveal how Spotify and Apple Music compete
+                across the streaming landscape.
               </p>
               <p class="project-details__desc-para">
-                Lorem ipsum dolor sit amet consectetur adipisicing elit. Neque
-                alias tenetur minus quaerat aliquid, aut provident blanditiis,
-                deleniti aspernatur ipsam eaque veniam voluptatem corporis vitae
-                mollitia laborum corrupti ullam rem?
+                Public datasets were cleaned and analysed with Python and SQL,
+                then visualised using Tableau and Power BI to highlight trends
+                and opportunities for each platform.
               </p>
             </div>
             <div class="project-details__tools-used">
               <h3 class="project-details__content-title">Tools Used</h3>
               <div class="skills">
-                <div class="skills__skill">HTML</div>
-                <div class="skills__skill">CSS</div>
-                <div class="skills__skill">JavaScript</div>
-                <div class="skills__skill">React</div>
-                <div class="skills__skill">SASS</div>
-                <div class="skills__skill">GIT</div>
-                <div class="skills__skill">Shopify</div>
-                <div class="skills__skill">Wordpress</div>
-                <div class="skills__skill">Google ADS</div>
-                <div class="skills__skill">Facebook Ads</div>
-                <div class="skills__skill">Android</div>
-                <div class="skills__skill">IOS</div>
+                <div class="skills__skill">Excel</div>
+                <div class="skills__skill">SQL</div>
+                <div class="skills__skill">Python</div>
+                <div class="skills__skill">Tableau</div>
+                <div class="skills__skill">Power BI</div>
               </div>
-            </div>
-            <div class="project-details__links">
-              <h3 class="project-details__content-title">See Live</h3>
-              <a
-                href="#"
-                class="btn btn--med btn--theme project-details__links-btn"
-                target="_blank"
-                >Live Link</a
-              >
-              <a
-                href="#"
-                class="btn btn--med btn--theme-inv project-details__links-btn"
-                target="_blank"
-                >Code Link</a
-              >
             </div>
           </div>
         </div>
@@ -171,48 +139,35 @@
               <span>Social</span>
             </h2>
             <div class="main-footer__social-cont">
-              <a target="_blank" rel="noreferrer" href="#">
+              <a
+                target="_blank"
+                rel="noreferrer"
+                href="https://linkedin.com/in/davale/"
+              >
                 <img
                   class="main-footer__icon"
                   src="./assets/png/linkedin-ico.png"
-                  alt="icon"
+                  alt="LinkedIn"
                 />
               </a>
-              <a target="_blank" rel="noreferrer" href="#">
-                <img
-                  class="main-footer__icon"
-                  src="./assets/png/github-ico.png"
-                  alt="icon"
-                />
-              </a>
-              <a target="_blank" rel="noreferrer" href="#">
-                <img
-                  class="main-footer__icon"
-                  src="./assets/png/twitter-ico.png"
-                  alt="icon"
-                />
-              </a>
-              <a target="_blank" rel="noreferrer" href="#">
-                <img
-                  class="main-footer__icon"
-                  src="./assets/png/yt-ico.png"
-                  alt="icon"
-                />
-              </a>
-              <a target="_blank" rel="noreferrer" href="#">
+              <a
+                target="_blank"
+                rel="noreferrer"
+                href="https://github.com/davalework"
+              >
                 <img
                   class="main-footer__icon main-footer__icon--mr-none"
-                  src="./assets/png/insta-ico.png"
-                  alt="icon"
+                  src="./assets/png/github-ico.png"
+                  alt="GitHub"
                 />
               </a>
             </div>
           </div>
           <div class="main-footer__row main-footer__row-2">
-            <h4 class="heading heading-sm text-lt">John Doe</h4>
+            <h4 class="heading heading-sm text-lt">David Adewale</h4>
             <p class="main-footer__short-desc">
-              Lorem ipsum dolor sit amet consectetur adipisicing elit facilis
-              tempora explicabo quae quod deserunt
+              Your data, my expertise. Together, we’ll unlock insights that
+              drive success.
             </p>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- Replace template placeholders with David Adewale’s branding, biography and contact information.
- Showcase "Spotify vs. Apple Music" case study and streamline skills and social links.

## Testing
- `npm install` *(fails: node-sass build error)*
- `npm run build` *(fails: npm-run-all not found after failed install)*

------
https://chatgpt.com/codex/tasks/task_e_68b9be52746483269d50ecbac658c263