### PR TITLE
Remove static contact info from contact section

### DIFF
--- a/index.html
+++ b/index.html
@@ -223,22 +223,7 @@
             success.
           </span>
         </h2>
-        <div class="contact__info">
-          <p>London, UK</p>
-          <p>
-            <a href="https://linkedin.com/in/davale/" target="_blank" rel="noreferrer"
-              >linkedin.com/in/davale/</a
-            >
-          </p>
-          <p>
-            <a href="https://github.com/davalework" target="_blank" rel="noreferrer"
-              >github.com/davalework</a
-            >
-          </p>
-          <p>
-            <a href="mailto:davalework@outlook.com">davalework@outlook.com</a>
-          </p>
-        </div>
+        <!-- Removed contact information left column -->
         <div class="contact__form-container">
           <form action="#" class="contact__form">
             <div class="contact__form-field">


### PR DESCRIPTION
## Summary
- drop the left-column contact info block from the contact section so only the form remains

## Testing
- `npm install` (fails: node-sass build error)
- `npm run build` (fails: npm-run-all not found)


------
https://chatgpt.com/codex/tasks/task_e_68b9ca812f508326ac2c007792d8ed4d