### PR TITLE
feat: add detailed spotify vs apple music report

### DIFF
--- a/project-1.html
+++ b/project-1.html
@@ -95,37 +95,135 @@
     <section class="project-details">
       <div class="main-container">
         <div class="project-details__content">
+          <div class="project-details__content-main">
+            <div class="project-details__desc">
+              <h3 class="project-details__content-title">
+                Spotify vs. Apple Music: Comparing the Titans of Music Streaming
+              </h3>
+              <p class="project-details__desc-para">
+                Music has gone digital, and two services have come to define how
+                we listen: Spotify and Apple Music. These two heavyweights are
+                vying for our ears with different philosophies: Spotify is the
+                party‑loving friend that always has a playlist for every mood
+                and moment, while Apple Music is the polished curator with deep
+                catalogues and a tight ecosystem. Both offer millions of tracks
+                but serve slightly different audiences and business models.
+              </p>
+
+              <h4 class="project-details__content-title">
+                Why this matters for your business
+              </h4>
+              <p class="project-details__desc-para">
+                Just as our entertainment habits reveal broader consumer trends,
+                analysing music streaming data can illuminate opportunities for
+                any organisation dealing with subscriptions, digital
+                distribution or user engagement.
+              </p>
+              <ul class="project-details__desc-para">
+                <li>
+                  <strong>Spot emerging opportunities.</strong> By comparing the
+                  growth curves of Spotify and Apple Music we can see which
+                  business models resonate with users and investors.
+                </li>
+                <li>
+                  <strong>Avoid hidden pitfalls.</strong> Annual income losses
+                  highlight how heavy investment in expansion can erode margins.
+                </li>
+                <li>
+                  <strong>Make sense of the numbers.</strong> Carefully designed
+                  visualisations and narratives make complex metrics
+                  understandable, even for non‑technical stakeholders.
+                </li>
+              </ul>
+
+              <h3 class="project-details__content-title">Objective</h3>
+              <p class="project-details__desc-para">
+                This project uses Tableau and simple statistical analysis to
+                unpack the financial and user‑based performance of Spotify and
+                Apple Music between 2015 and 2024. It explores revenue
+                dominance, audience reach, premium conversion and the geographic
+                markets driving growth.
+              </p>
+
+              <h3 class="project-details__content-title">Round 1: Revenue Rumble!</h3>
+              <p class="project-details__desc-para">
+                Over the ten‑year window Spotify generated roughly
+                $79.63&nbsp;billion in revenue compared with Apple Music’s
+                $52.96&nbsp;billion. The gap widened in 2024, with Spotify
+                reporting about $15.62&nbsp;billion to Apple Music’s
+                $10.12&nbsp;billion.
+              </p>
+
+              <h3 class="project-details__content-title">Round 2: User Uprising</h3>
+              <p class="project-details__desc-para">
+                When it comes to premium subscribers, Spotify again leads. In
+                2024 it boasted roughly 246&nbsp;million paying users, up from
+                22&nbsp;million in 2015. Apple Music climbed from 6.5&nbsp;million
+                to about 95&nbsp;million subscribers over the same period.
+              </p>
+
+              <h3 class="project-details__content-title">Round 3: Premium Powerhouse</h3>
+              <p class="project-details__desc-para">
+                Both platforms saw meteoric rises in paid subscribers, but the
+                growth trajectory differs. Spotify’s premium membership expanded
+                more than eleven‑fold from 2015 to 2024, while Apple Music’s
+                growth rate decelerated after 2019.
+              </p>
+
+              <h3 class="project-details__content-title">Round 4: Geography Games</h3>
+              <p class="project-details__desc-para">
+                Regional data reveal where the money flows. For Spotify, EMEA was
+                the biggest contributor in 2024, delivering roughly
+                $5.84&nbsp;billion. Asia‑Pacific and US&nbsp;&amp;&nbsp;Canada followed
+                closely, while Latin America generated the least revenue yet
+                showed the fastest growth rate.
+              </p>
+
+              <h3 class="project-details__content-title">Round 5: The loss Rollercoaster</h3>
+              <p class="project-details__desc-para">
+                Growth isn’t cheap. Spotify’s annual income loss fluctuated
+                dramatically over the decade, bottoming out at –$1.24&nbsp;billion
+                in 2017 and rising to a $1.14&nbsp;billion loss in 2024.
+              </p>
+
+              <h3 class="project-details__content-title">Conclusion</h3>
+              <p class="project-details__desc-para">
+                Spotify takes the lead on revenue and user count, powered by a
+                freemium model, innovative recommendations and relentless global
+                expansion. Apple Music offers a more curated experience and
+                enjoys a fiercely loyal user base, but its closed ecosystem
+                limits total scale.
+              </p>
+
+              <p class="project-details__desc-para">
+                This project took me on an exciting data‑driven exploration of
+                the music streaming industry, leveraging skills including data
+                analysis, visualisation and storytelling.
+              </p>
+            </div>
+            <div class="project-details__tools-used">
+              <h3 class="project-details__content-title">Key Skills</h3>
+              <div class="skills">
+                <div class="skills__skill">Data analysis</div>
+                <div class="skills__skill">Visualisation</div>
+                <div class="skills__skill">Storytelling</div>
+              </div>
+            </div>
+            <div class="project-details__links">
+              <a
+                href="https://github.com/muskan0830/Youtube-Vs-Netflix-Tableau/tree/main"
+                class="btn btn--med btn--theme project-details__links-btn"
+                target="_blank"
+                >View the Code</a
+              >
+            </div>
+          </div>
           <div class="project-details__showcase-img-cont">
             <img
               src="./assets/jpeg/spotAppleDash.jpeg"
               alt="Project Image"
               class="project-details__showcase-img"
             />
-          </div>
-          <div class="project-details__content-main">
-            <div class="project-details__desc">
-              <h3 class="project-details__content-title">Project Overview</h3>
-              <p class="project-details__desc-para">
-                A deep dive into revenue, user growth, premium conversion, and
-                geographic reach to reveal how Spotify and Apple Music compete
-                across the streaming landscape.
-              </p>
-              <p class="project-details__desc-para">
-                Public datasets were cleaned and analysed with Python and SQL,
-                then visualised using Tableau and Power BI to highlight trends
-                and opportunities for each platform.
-              </p>
-            </div>
-            <div class="project-details__tools-used">
-              <h3 class="project-details__content-title">Tools Used</h3>
-              <div class="skills">
-                <div class="skills__skill">Excel</div>
-                <div class="skills__skill">SQL</div>
-                <div class="skills__skill">Python</div>
-                <div class="skills__skill">Tableau</div>
-                <div class="skills__skill">Power BI</div>
-              </div>
-            </div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- expand project-1 page with full Spotify vs Apple Music comparison report
- outline project objectives, revenue and user growth insights, and key skills
- move project screenshot to bottom of report for emphasis

## Testing
- `npm install` *(fails: node-sass build error)*
- `npm run build` *(fails: npm-run-all not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b9d6e315448326b1ccaa952d99761a